### PR TITLE
DPR2-46: Deploy lambdas to pre-prod

### DIFF
--- a/preprod/digital-prison-reporting-lambdas.yml
+++ b/preprod/digital-prison-reporting-lambdas.yml
@@ -1,0 +1,8 @@
+release:
+  project: digital-prison-reporting-lambdas
+  release_type: gradle
+  release_category: backend
+  tag: v0.0.6
+  extra_args:
+    refresh_lambda: true
+    refresh_function: dpr-pipeline-notification-function


### PR DESCRIPTION
This PR deploys the `digital-prison-reporting-lambdas` version v0.0.6 to pre-production.