### PR TITLE
DPR2-511: Bump version of jobs in pre-prod

### DIFF
--- a/preprod/digital-prison-reporting-jobs.yml
+++ b/preprod/digital-prison-reporting-jobs.yml
@@ -3,4 +3,4 @@ release:
   release_type: gradle
   release_category: backend
   tag: v1.0.55
-  bump: 2
+  bump: 3


### PR DESCRIPTION
This PR bumps the version of the jobs in pre-prod just to verify that the gradle tests complete successfully with the CircleCI resource class of large