### PR TITLE
DPR2-892: Deploy domains v0.0.56 to preprod

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-domains
   release_type: terraform
   release_category: backend
-  tag: v0.0.52
+  tag: v0.0.56
   bump: 1
   s3_sync_args:
     app_dir: ./project


### PR DESCRIPTION
- Adds the glue data connection to the jobs
- Adds perms to access the Operational DataStore secret