### PR TITLE
DPR2-892: Deploy jobs v1.0.71 to preprod.

### DIFF
--- a/preprod/digital-prison-reporting-jobs.yml
+++ b/preprod/digital-prison-reporting-jobs.yml
@@ -3,7 +3,7 @@ release:
   release_type: gradle
   release_category: backend
   tag: v1.0.71
-  bump: 1
+  bump: 2
   s3_sync_args:
     app_dir: ./project
     bucket_prefix: dpr-artifact-store

--- a/preprod/digital-prison-reporting-jobs.yml
+++ b/preprod/digital-prison-reporting-jobs.yml
@@ -2,8 +2,8 @@ release:
   project: digital-prison-reporting-jobs
   release_type: gradle
   release_category: backend
-  tag: v1.0.70
-  bump: 2
+  tag: v1.0.71
+  bump: 1
   s3_sync_args:
     app_dir: ./project
     bucket_prefix: dpr-artifact-store


### PR DESCRIPTION
- Fixes issue when running integration tests in release pipeline
- Re-releases jobs latest changes for operational DataStore after pipeline failure last time