### PR TITLE
DPR2-1435: Deploy domains v0.0.122 to pre-prod

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-domains
   release_type: terraform
   release_category: backend
-  tag: v0.0.119
+  tag: v0.0.122
   bump: 1
   s3_sync_args:
     app_dir: ./project


### PR DESCRIPTION
Destroys most DPS Case Notes resources in Pre-Prod as a pre-cursor to recreating DMS sources with updated heartbeat settings