### PR TITLE
DPR2-1435: Bump domains v0.0.122 in pre-prod

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -3,7 +3,7 @@ release:
   release_type: terraform
   release_category: backend
   tag: v0.0.122
-  bump: 1
+  bump: 2
   s3_sync_args:
     app_dir: ./project
     bucket_prefix: dpr-glue-jobs


### PR DESCRIPTION
One of the DMS jobs was running previously which failed the terraform plan. I will rerun this once all jobs are paused.