### PR TITLE
DPR2-1435: Release domains v0.0.123 to pre-prod

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-domains
   release_type: terraform
   release_category: backend
-  tag: v0.0.122
+  tag: v0.0.123
   bump: 2
   s3_sync_args:
     app_dir: ./project


### PR DESCRIPTION
Recreates the previously removed DPS Case notes resources in Pre-prod in order for heartbeat interval to take effect