### PR TITLE
DPR2-1445: Deploy domains v0.0.163 to Pre-Prod.

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-domains
   release_type: terraform
   release_category: backend
-  tag: v0.0.162
+  tag: v0.0.163
   bump: 1
   s3_sync_args:
     app_dir: ./project


### PR DESCRIPTION
Removes locations_regions table from BaSM ingestion due to lack of primary key.