### PR TITLE
DPR2-1744: Deploy domains v0.0.176 to pre-prod

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-domains
   release_type: terraform
   release_category: backend
-  tag: v0.0.174
+  tag: v0.0.176
   bump: 1
   s3_sync_args:
     app_dir: ./project


### PR DESCRIPTION
Upgrade end of life DMS instance types:

- R4 -> R5
- C4 -> C5
- T2 -> T3


From AWS:

```Q - What instance type(s) will my Replication instances be auto-upgraded to?
• We will make our best effort to upgrade your Replication instance from C4→C5, M4→R5, R4→R5, and T2→T3 and typically keep its original sizes.
• In cases that we cannot keep the original size, we will first attempt to migrate your Replication instance to another Availability Zone (AZ) in the same region. If this is unsuccessful, we will migrate your Replication instances to one size smaller than its original size.
• The upgraded instance types are priced identically or lower than the older generation instance types. For the most up-to-date prices, please refer to the AWS DMS pricing page [1].```
