### PR TITLE
DPR2-1930: Deploy domains v0.0.244 to Pre-Prod.

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-domains
   release_type: terraform
   release_category: backend
-  tag: v0.0.243
+  tag: v0.0.244
   bump: 1
   s3_sync_args:
     app_dir: ./project


### PR DESCRIPTION
Tunes basm glue_cdc_job_max_records_per_file to 700000.