### PR TITLE
DPR2-2008 added Java executor tag for multiphase query

### DIFF
--- a/preprod/hmpps-dpr-multiphase-query-lambda.yml
+++ b/preprod/hmpps-dpr-multiphase-query-lambda.yml
@@ -3,6 +3,9 @@ release:
   release_type: gradle
   release_category: backend
   tag: v0.0.4
+  executor:
+    name: reporting/java
+    tag: 21.0
   extra_args:
     refresh_lambda: false
     refresh_function: dpr-multiphase-query-function


### PR DESCRIPTION
Based on the new changes from https://dsdmoj.atlassian.net/browse/DPR2-2008 added Java executor tag for multiphase query.