### PR TITLE
DPR2-1499: Bump domains v0.0.276 release.

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -6,7 +6,7 @@ release:
     name: reporting/terraform-aws
     tag: v1.10.0-awscliv1-1.0.2
   tag: v0.0.276
-  bump: 1
+  bump: 2
   s3_sync_args:
     app_dir: ./project
     bucket_prefix: dpr-glue-jobs


### PR DESCRIPTION
Bumping to re-deploy domains v0.0.276 because it hasn't synced the configs