### PR TITLE
DPR2-1897 Updated domains to latest tag

### DIFF
--- a/preprod/digital-prison-reporting-domains.yml
+++ b/preprod/digital-prison-reporting-domains.yml
@@ -5,7 +5,7 @@ release:
   executor:
     name: reporting/terraform-aws
     tag: v1.10.0-awscliv1-1.0.2
-  tag: v0.0.286
+  tag: v0.0.290
   bump: 1
   s3_sync_args:
     sync_artifacts: true


### PR DESCRIPTION
Deploy version 0.0.290 of domains to preprod.
This is following the below fix:
https://github.com/ministryofjustice/digital-prison-reporting-domains/pull/442