### PR TITLE
DPR2-2143 Updated third party components to latest tag

### DIFF
--- a/prod/digital-prison-reporting-thirdparty-components.yml
+++ b/prod/digital-prison-reporting-thirdparty-components.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-thirdparty-components
   release_type: thirdparty_artifacts
   release_category: backend
-  tag: v0.0.10
+  tag: v0.0.11
   executor:
     name: reporting/base
     tag: 3.10


### PR DESCRIPTION
This tag contains the Athena Redshift connector Jar which has been deployed up to Preprod.
The latest version of Domains uses this and it needs to be present in S3 before releasing Domains.