### PR TITLE
DPR2-2681: Deploy Redshift Transfer Component v0.0.57 to Production.

### DIFF
--- a/prod/digital-prison-reporting-transfer-component-redshift.yml
+++ b/prod/digital-prison-reporting-transfer-component-redshift.yml
@@ -2,7 +2,7 @@ release:
   project: digital-prison-reporting-transfer-component
   release_type: flyway
   release_category: backend
-  tag: v0.0.55
+  tag: v0.0.57
   bump: 1
   executor:
     name: reporting/aws


### PR DESCRIPTION
This promotes the latest DPR2-2681 person prisoner and DPR2-2881 SAN prisoner challenges and conditions changes from Pre-Prod to Prod.

On merge it will carry out the Production deployment via flyway.